### PR TITLE
Added code to support verbose/concise message logging.

### DIFF
--- a/eddblink-listener.py
+++ b/eddblink-listener.py
@@ -481,7 +481,9 @@ def process_messages():
         try:
             station_id = station_ids[system.upper() + "/" + station.upper()]
         except KeyError:
-            print("ERROR: Not found in Stations: " + system + "/" + station)
+            # [MarkAusten] Skip output if not verbose
+            if config['verbose']:
+                print("ERROR: Not found in Stations: " + system + "/" + station)
             continue
         
         modified = entry.timestamp.replace('T',' ').replace('Z','')

--- a/eddblink-listener.py
+++ b/eddblink-listener.py
@@ -586,7 +586,7 @@ config = load_config()
 # [MarkAusten] Set the verbose flag from the config settings. If not found then verbose is assumed.
 # [MarkAusten] Note: This only checks for a 'verbose' setting, anything else is assumed to be 'concise'.
 if 'message_output' in config:
-    verbose = config['message_output'] == 'verbose'
+    verbose = config['message_output'].lower() == 'verbose'
 else:
     verbose = True
 

--- a/eddblink-listener.py
+++ b/eddblink-listener.py
@@ -20,7 +20,6 @@ from collections import defaultdict, namedtuple, deque, OrderedDict
 from distutils.version import LooseVersion
 from macpath import curdir
 
-
 # Copyright (C) Oliver 'kfsone' Smith <oliver@kfs.org> 2015
 #
 # Conditional permission to copy, modify, refactor or use this
@@ -550,10 +549,10 @@ def process_messages():
 
             # [MarkAusten] output appripriate message
             if config['verbose']:
-            	print("Market update for " + system + "/" + station\
+                print("Market update for " + system + "/" + station\
                   + " finished in " + str(datetime.datetime.now() - start_update) + " seconds.")
             else:
-				print( "Updated " + system + "/" + station)
+                print( "Updated " + system + "/" + station)
 
     print("Shutting down message processor.")
 


### PR DESCRIPTION
I have added the code to allow the user to show concise or verbose menages to the console. In verbose mode the messages are unchanged from the master version. In concise mode the error messages about rare items and missing commodities (etc) are skipped and the main loop message is shortened to show just "Updated" plus the system and station name.

There is a new conflict setting to control this named 'message_output' and if this is missing or set to 'verbose' then the verbose mode is set otherwise the logging is concise. This is currently case sensitive.

I have tested this with no config setting, the setting set to 'verbose', 'concise', 'zzz' and a blank string. All show the expected output.

The load_config method has been modified to add the 'message_output' item set to 'verbose' by default meaning that the behaviour out-of-the-box is the same as before.

I have annotated each of the changes with # [MarkAusten] plus a comment.