### PR TITLE
Add in new debug option to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,38 @@ A note on the whitelist:
 - Software entries /with/ a minversion mean messages from a version lower than minversion will not be accepted, but those >= minversion will.
 
 If you wish, you may copy this as "eddblink-listener-config.json" in the same folder as the program itself and make any changes to it before running the program, in order to avoid having to run it, waiting for the default config file to be created, stopping it, making the changes, and then running the program again.
+
+# How it works
+
+The EDDBlink-listener program consists runs either three or four separate threads:
+1) The actual listener, which is started as soon as the startup process is complete.
+This is the thread that listens for messages and adds them to the queue.
+
+2) The update checker, which is started right after the listener.
+This is the method that runs the EDDBlink plugin when it detects an update to the EDDB dump have occurred.
+Before it starts the updates, it signals that it needs the DB: "EDDB update available, waiting for busy signal acknowledgement before proceeding.".
+It then waits for the listings exporter and message processor to signal they got the signal and are waiting for the update checker to complete, and then runs the update.
+When it's finished, it signals completion to the exporter and processor, and they both unpause.
+
+A note on the updating:
+The EDDBlink plugin actually does the updating, all the update checker does if see if there's an update available and if so calls the plugin.
+When the EDDBlink plugin runs, if the data from the EDDB listings is newer than the DB data, it updates the data, setting the "from_live" flag to 0.
+If the data from the EDDB listings is the same age as the data in the DB, meaning the live data from the day before has made it to the latest dump, it leaves the data alone but sets its "from_live" flag to 0.
+If the data from the EDDB listings is older than the DB data, it skips that data and doesn't do anything to the data in the DB.
+
+3) The listings exporter, which is started 5 seconds after the update checker in order to give the checker enough time to check if it needs to update immediately.
+This is not run when the listener is running as a client. In that case, it "permanently" (i.e. as long as the program is running) turns on the busy signal acknowledgement and shuts itself down.
+When it's not currently active and gets a busy signal from the update checker, it acknowledges it, "Listings exporter acknowledging busy signal.", and pauses itself until it gets the no-longer-busy signal, "Busy signal off, listings exporter resuming."
+When it begins exporting the listings, it sends a signal to the message processor that it needs the DB, "Listings exporter sending busy signal."
+It doesn't need to send one to the update checker, because the update checker will wait for acknowledgement from the exporter, and the exporter won't give that until it's done exporting.
+Once it gets acknowledgement from the message processor, it grabs all the listings that have been updated since the last dump, i.e., all the listings that have a "from_live" value of 1.
+Once it's gotten them, it relinquishes the DB and turns off its busy signal, allowing the message processor to resume.
+It then exports all the listings it got to the live listings file.
+
+4) The message processor, which is started immediately after the listings exporter.
+This is the method that actually puts the messages from the EDDN into the database.
+If it receives a busy signal from either the update checker or the listings exporter, it pauses, "Message processor acknowledging busy signal."
+When the busy signal(s) are turned off, it resumes from where it left off, "Busy signal off, message processor resuming."
+When it is active, it pulls the first message from the queue being built up by the listener, does some processing, and inserts it into the DB, setting the "from_live" flag for each entry it inserts to 1.
+If there are still messages in the queue, it immediately proceeds to process the next message.
+If there are no messages in the queue remaining, it tells the DB to commit the changes it has made.

--- a/README.md
+++ b/README.md
@@ -70,12 +70,12 @@ If you wish, you may copy this as "eddblink-listener-config.json" in the same fo
 
 # How it works
 
-The EDDBlink-listener program consists runs either three or four separate threads:
+The EDDBlink-listener program runs either three or four separate threads:
 1) The actual listener, which is started as soon as the startup process is complete.
 This is the thread that listens for messages and adds them to the queue.
 
 2) The update checker, which is started right after the listener.
-This is the method that runs the EDDBlink plugin when it detects an update to the EDDB dump have occurred.
+This is the method that runs the EDDBlink plugin when it detects an update to the EDDB dump has occurred.
 Before it starts the updates, it signals that it needs the DB: "EDDB update available, waiting for busy signal acknowledgement before proceeding.".
 It then waits for the listings exporter and message processor to signal they got the signal and are waiting for the update checker to complete, and then runs the update.
 When it's finished, it signals completion to the exporter and processor, and they both unpause.
@@ -95,7 +95,7 @@ Once it gets acknowledgement from the message processor, it grabs all the listin
 Once it's gotten them, it relinquishes the DB and turns off its busy signal, allowing the message processor to resume.
 It then exports all the listings it got to the live listings file.
 
-4) The message processor, which is started immediately after the listings exporter.
+4) The message processor, which is started 5 seconds after the update checker, immediately after the listings exporter.
 This is the method that actually puts the messages from the EDDN into the database.
 If it receives a busy signal from either the update checker or the listings exporter, it pauses, "Message processor acknowledging busy signal."
 When the busy signal(s) are turned off, it resumes from where it left off, "Busy signal off, message processor resuming."


### PR DESCRIPTION
Rather than use the existing and useful 'verbose' to output additional debug messages - make a completely separate option. 

This also negates the need to remove potentially still useful debug output (as in https://github.com/eyeonus/EDDBlink-listener/issues/7 which is still open as "probably solved) simply to get back to 'normal' verbose behaviour.

Thus this PR also adds back in the debug output from ec2e39a, to output when debug==true.