### PR TITLE
Fix plugin list, tdb definition location

### DIFF
--- a/tradedangerous_listener.py
+++ b/tradedangerous_listener.py
@@ -1252,13 +1252,15 @@ dump_busy = False
 go = True
 q = deque()
 
+tdb = tradedb.TradeDB(load = False)
+
 dataPath = os.environ.get('TD_CSV') or Path(tradeenv.TradeEnv().csvDir).resolve()
 eddbPath = plugins.eddblink_plug.ImportPlugin(tdb, tradeenv.TradeEnv()).dataPath
 
 config = load_config()
 if config['client_options'] == 'clean' or not Path(dataPath, 'TradeDangerous.db').exists():
     print("Initial run")
-    trade.main(('trade.py', 'import', '-P', 'eddblink', '-O', 'clean, solo'))
+    trade.main(('trade.py', 'import', '-P', 'eddblink', '-O', 'clean,solo'))
     config['client_options'] = 'all'
     with open("tradedangerous-listener-config.json", "w") as config_file:
         json.dump(config, config_file, indent=4)
@@ -1290,7 +1292,6 @@ live_thread = threading.Thread(target = export_live)
 
 if config['verbose']:
     print("Loading TradeDB")
-tdb = tradedb.TradeDB(load = False)
 
 if config['verbose']:
     print("Updating dicts")


### PR DESCRIPTION
This fixes two bugs (bad practice for one commit, probably)
1. `tdb` is not defined when running this script (because `tdb` is used slightly before it is defined)
2. Apparently spaces in the plugin list leads to a space in the plugin name passed to the td script